### PR TITLE
Ability to pass dbName in mongoData parameter for mongoose connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function MongooseMorgan(mongoData, options, format) {
     mongoose.connect(mongoData.connectionString, {
         user: mongoData.user || null,
         pass: mongoData.pass || null,
+        dbName: mongoData.dbName || null,
         useNewUrlParser: true
     });
 


### PR DESCRIPTION
From [mongoose docs](https://mongoosejs.com/docs/connections.html): 

> "If you're using the mongodb+srv syntax to connect to MongoDB Atlas, you should use dbName to specify the database because you currently cannot in the connection string."
