### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var morgan = require('mongoose-morgan');
 var port = process.env.port || 8080;
 
 // Logger
-app.use(morgan({
+app.use(morgan("combined", {
     connectionString: 'mongodb://localhost:27017/logs-db'
 }));
 
@@ -62,7 +62,8 @@ The example from the above will create inside `logs-db` database collection call
 Example without morgan options:
 
 ```
-app.use(morgan({
+app.use(morgan("combined",
+   {
     connectionString: 'mongodb://localhost:27017/logs-db'
    }, {}, 'short'
 ));
@@ -71,7 +72,8 @@ app.use(morgan({
 Full example:
 
 ```
-app.use(morgan({
+app.use(morgan("combined",
+   {
     collection: 'error_logger',
     connectionString: 'mongodb://localhost:27017/logs-db',
     user: 'admin',


### PR DESCRIPTION
I updated the readme to fix the examples. Currently, the examples throw deprecation notices. By changing the format it no longer throws the deprecation warnings.